### PR TITLE
WIP: `windows()` support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,16 +32,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/R/event-loop.R
+++ b/R/event-loop.R
@@ -357,7 +357,7 @@ run_loop <- function(user_func, init_func = NULL, width = 7, height = 7,
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Sanity Check: Operating System
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  if (.Platform$OS.type == 'windows') {
+  if (.Platform$OS.type == 'windows' && getRversion() < '4.7.0') {
     stop("The 'eventloop' package is not compatible with windows because the ",
          "graphics devices do not support the required interaction events")
   }
@@ -393,7 +393,11 @@ run_loop <- function(user_func, init_func = NULL, width = 7, height = 7,
   # Create a device and capture its device number.
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   devs1 <- dev.list()
-  grDevices::x11(type = type, width = width, height = height)
+  if (.Platform$OS.type == 'windows') {
+    grDevices::windows(buffered = double_buffer, width = width, height = height)
+  } else {
+    grDevices::x11(type = type, width = width, height = height)
+  }
   devs2 <- dev.list()
   this_dev <- setdiff(devs2, devs1)
   on.exit(grDevices::dev.off(which = this_dev))

--- a/vignettes/verbose-example.Rmd
+++ b/vignettes/verbose-example.Rmd
@@ -80,7 +80,7 @@ verbose <- function(event, mouse_x, mouse_y, frame_num, fps_actual,
     last_y <<- mouse_y
     
     # "Handle" the event by printing to console
-    co <- sprintf("Screen [%i, %i] Mouse Loc: [%.2f, %.2f]", dev_width, dev_height, mouse_x, mouse_y)
+    co <- sprintf("Screen [%.0f, %.0f] Mouse Loc: [%.2f, %.2f]", dev_width, dev_height, mouse_x, mouse_y)
     if (event$type %in% c('mouse_down', 'mouse_up', 'mouse_move')) {
       cat(co, "Mouse: ", event$type, " - button: [", event$button, "]\n")
     } else if (event$type == 'mouse_move') {
@@ -150,7 +150,7 @@ Agent <- R6::R6Class(
         self$last_y <- mouse_y
         
         # "Handle" the event by printing to console
-    co <- sprintf("Screen [%i, %i] Mouse Loc: [%.2f, %.2f]", dev_width, dev_height, mouse_x, mouse_y)
+    co <- sprintf("Screen [%.0f, %.0f] Mouse Loc: [%.2f, %.2f]", dev_width, dev_height, mouse_x, mouse_y)
         if (event$type %in% c('mouse_down', 'mouse_up')) {
           cat(co, "Mouse: ", event$type, " - button: [", event$button, "]\n")
         } else if (event$type == 'mouse_move') {


### PR DESCRIPTION
* Minimal changes to get {eventloop} to work with R-devel (currently R 4.7.0) that has been patched with support for an Idle event
* Probably shouldn't merge until such a patch is actually accepted and merged into R (which may be after R 4.7.0 is released) but in the meantime this branch is great for testing any such patch